### PR TITLE
Highlighting currently selected tab

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -184,6 +184,29 @@ class AllInOneClipboardIndicator extends PanelMenu.Button {
     }
 
     /**
+     * Updates the visual state of the tab buttons so the active tab is highlighted.
+     * Mirrors the approach used by category viewers for consistency.
+     * @private
+     */
+    _updateTabButtonSelection() {
+        if (!this._tabButtons) {
+            return;
+        }
+
+        for (const [name, button] of Object.entries(this._tabButtons)) {
+            if (!button) {
+                continue;
+            }
+
+            if (name === this._activeTabName) {
+                button.add_style_pseudo_class('checked');
+            } else {
+                button.remove_style_pseudo_class('checked');
+            }
+        }
+    }
+
+    /**
      * Disconnects signals from the previously active tab's content actor.
      * @param {St.Actor} tabActor - The actor of the tab content being deactivated.
      * @private
@@ -226,6 +249,7 @@ class AllInOneClipboardIndicator extends PanelMenu.Button {
         // Update state
         this._activeTabName = tabName;
         this._lastActiveTabName = tabName;
+        this._updateTabButtonSelection();
         const tabId = getTabIdentifier(tabName);
         const isNewTabFullView = this._fullViewTabs.includes(tabName);
 


### PR DESCRIPTION
Currently, it is a bit difficult to tell which page you are on because the tab is not highlighted. This highlighting functionality already exists in the emojis, symbols, etc pages. Highlighting the current tab makes it more clear to the user where they are. This is only relevant for the recents and clipboard tabs; the others (eg emojis) open a separate page anyway so for those it is obvious where the user is. 

<img width="586" height="583" alt="image" src="https://github.com/user-attachments/assets/8a7d0c89-bfae-4b43-93ef-c24c16028a20" />
