### PR TITLE
Allow Disabling Tabs + Always Show Tabs 

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -333,6 +333,30 @@ class AllInOneClipboardIndicator extends PanelMenu.Button {
         this._setMainTabBarVisibility();
     }
 
+
+    /**
+     * Updates the visual state of the tab buttons so the active tab is highlighted.
+     * Mirrors the approach used by category viewers for consistency.
+     * @private
+     */
+    _updateTabButtonSelection() {
+        if (!this._tabButtons) {
+            return;
+        }
+
+        for (const [name, button] of Object.entries(this._tabButtons)) {
+            if (!button) {
+                continue;
+            }
+
+            if (name === this._activeTabName) {
+                button.add_style_pseudo_class('checked');
+            } else {
+                button.remove_style_pseudo_class('checked');
+            }
+        }
+    }
+
     /**
      * Disconnects signals from the previously active tab's content actor.
      * @param {St.Actor} tabActor - The actor of the tab content being deactivated.
@@ -393,6 +417,7 @@ class AllInOneClipboardIndicator extends PanelMenu.Button {
         // Update state
         this._activeTabName = tabName;
         this._lastActiveTabName = tabName;
+        this._updateTabButtonSelection();
         const tabId = getTabIdentifier(tabName);
 
         // Visibility Management


### PR DESCRIPTION
- At least one tab must remain active
- When all but 1 tab are disabled, the last tab is grayed out to prevent the user from disabling it
- When there is only one tab left, the tabs are no longer shown as the user cannot select anything else anyway
- Reverted the functionality to hide Gifs tab when no provider is selected
- Always show the tabs even when going to pages such as emojis, symbols, etc. This is because when disabling the recents tab, pressing the back button has nowhere to go. We can redirect to another tab like clipboard but when both the clipboard and recents are disabled there is actually no page that the user can go back to. Removing the back button and keeping the tabs always visible completely skips this step of going back. This also removes a lot of logic related to going back cleaning up the code. 
- Highlight current tab to make it clear to the user where they are

<img width="1655" height="870" alt="image" src="https://github.com/user-attachments/assets/6d6f3cb2-faf8-487a-8b21-305897f318e1" />

<img width="1655" height="870" alt="image" src="https://github.com/user-attachments/assets/5933fc99-056d-4cd5-a410-bbfd8d4c47de" />

<img width="1655" height="870" alt="image" src="https://github.com/user-attachments/assets/ce8b9ac4-2efe-46fd-a4e6-11eaf8172dfd" />

