### PR TITLE
Allows disabling the recents tab

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -32,7 +32,7 @@ const TABS = [
         name: "Recently Used",
         icon: 'utility-recents-symbolic.svg',
         isFullView: false,
-        settingKey: null
+        settingKey: 'enable-recents-tab'
     },
     {
         name: "Emoji",
@@ -98,6 +98,7 @@ class AllInOneClipboardIndicator extends PanelMenu.Button {
         this._selectTabTimeoutId = 0;
         this._loadingIndicatorTimeoutId = 0;
         this._tabVisibilitySignalIds = [];
+        this._visibleTabNames = new Set();
 
         const icon = new St.Icon({ icon_name: 'edit-copy-symbolic', style_class: 'system-status-icon' });
         this.add_child(icon);
@@ -303,19 +304,32 @@ class AllInOneClipboardIndicator extends PanelMenu.Button {
                 visibleTabs.add(name);
             }
         });
+        this._visibleTabNames = visibleTabs;
 
         // Ensure that the active and last active tabs are visible
-        const safeFallback = _("Recently Used");
-        if (this._activeTabName && !visibleTabs.has(this._activeTabName)) {
+        const fallbackTarget = this._getFirstVisibleTabName();
+        if (this._activeTabName && !visibleTabs.has(this._activeTabName) && fallbackTarget) {
             if (this.menu?.isOpen) {
-                this._selectTab(safeFallback);
+                this._selectTab(fallbackTarget);
             } else {
-                this._activeTabName = safeFallback;
+                this._activeTabName = fallbackTarget;
             }
         }
-        if (this._lastActiveTabName && !visibleTabs.has(this._lastActiveTabName)) {
-            this._lastActiveTabName = safeFallback;
+        if (this._lastActiveTabName && !visibleTabs.has(this._lastActiveTabName) && fallbackTarget) {
+            this._lastActiveTabName = fallbackTarget;
         }
+    }
+
+    /**
+     * Retrieves the first visible tab name based on the current user order.
+     * @returns {string|null} The translated tab name if available, otherwise null.
+     * @private
+     */
+    _getFirstVisibleTabName() {
+        for (const name of this._visibleTabNames) {
+            return name;
+        }
+        return null;
     }
 
     /**
@@ -473,7 +487,14 @@ class AllInOneClipboardIndicator extends PanelMenu.Button {
                 if (GObject.signal_lookup('navigate-to-main-tab', newContentActor.constructor.$gtype)) {
                     this._currentTabNavigateSignalId = newContentActor.connect('navigate-to-main-tab', (actor, targetTabName) => {
                         if (this.TAB_NAMES.includes(targetTabName)) {
-                            this._selectTab(targetTabName);
+                            if (this._visibleTabNames.has(targetTabName)) {
+                                this._selectTab(targetTabName);
+                            } else {
+                                const fallbackTab = this._getFirstVisibleTabName();
+                                if (fallbackTab) {
+                                    this._selectTab(fallbackTab);
+                                }
+                            }
                         }
                     });
                 }

--- a/extension/schemas/org.gnome.shell.extensions.all-in-one-clipboard.gschema.xml
+++ b/extension/schemas/org.gnome.shell.extensions.all-in-one-clipboard.gschema.xml
@@ -29,6 +29,10 @@
             <summary>The tab to open by default.</summary>
             <description>Defines which tab is opened when the menu is activated via the panel icon or main toggle shortcut.</description>
         </key>
+        <key name="enable-recents-tab" type="b">
+            <default>true</default>
+            <summary>Enable the 'Recently Used' tab</summary>
+        </key>
         <key name="enable-emoji-tab" type="b">
             <default>true</default>
             <summary>Enable the 'Emoji' tab</summary>


### PR DESCRIPTION
- When there is only one tab it cannot be disabling
- Last enabled tab is grayed out in the settings

**Recents Tab Disabled**
<img width="683" height="612" alt="image" src="https://github.com/user-attachments/assets/bc4884ff-d429-4ca3-9ecc-57e6b2622518" />

**Last Item cannot be disabled**
<img width="762" height="698" alt="image" src="https://github.com/user-attachments/assets/2660bd1f-bcde-4fe0-8eba-89f5a7a6b181" />

Issue #19