### PR TITLE
Added option to always show tabs at the top

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -92,6 +92,7 @@ class AllInOneClipboardIndicator extends PanelMenu.Button {
         this._mainTabBar = null;
         this._explicitTabTarget = null;
         this._isOpeningViaShortcut = false;
+        this._alwaysShowTabBar = this._settings.get_boolean('always-show-tab-bar');
 
         this._currentTabVisibilitySignalId = 0;
         this._currentTabNavigateSignalId = 0;
@@ -115,6 +116,12 @@ class AllInOneClipboardIndicator extends PanelMenu.Button {
         // Listen for changes to the tab order and rebuild the tab bar in real-time.
         const tabOrderSignalId = this._settings.connect('changed::tab-order', () => this._rebuildTabBar());
         this._tabVisibilitySignalIds.push(tabOrderSignalId);
+
+        const alwaysShowTabsSignalId = this._settings.connect('changed::always-show-tab-bar', () => {
+            this._alwaysShowTabBar = this._settings.get_boolean('always-show-tab-bar');
+            this._updateTabBarVisibilityForActiveTab();
+        });
+        this._tabVisibilitySignalIds.push(alwaysShowTabsSignalId);
 
         // Run once on startup to set the initial state.
         this._updateTabsVisibility();
@@ -251,9 +258,23 @@ class AllInOneClipboardIndicator extends PanelMenu.Button {
      * @private
      */
     _setMainTabBarVisibility(isVisible) {
-        if (this._mainTabBar && this._mainTabBar.visible !== isVisible) {
-            this._mainTabBar.visible = isVisible;
+        const targetVisibility = this._alwaysShowTabBar ? true : isVisible;
+
+        if (this._mainTabBar && this._mainTabBar.visible !== targetVisibility) {
+            this._mainTabBar.visible = targetVisibility;
         }
+    }
+
+    _shouldShowTabBarForTab(tabName) {
+        if (this._alwaysShowTabBar || !tabName) {
+            return true;
+        }
+
+        return !this._fullViewTabs.includes(tabName);
+    }
+
+    _updateTabBarVisibilityForActiveTab() {
+        this._setMainTabBarVisibility(this._shouldShowTabBarForTab(this._activeTabName));
     }
 
     /**

--- a/extension/features/Kaomoji/tabKaomoji.js
+++ b/extension/features/Kaomoji/tabKaomoji.js
@@ -34,6 +34,7 @@ class KaomojiTabContent extends St.Bin {
 
         // Store settings for later use
         this._settings = settings;
+        this._alwaysShowTabsSignalId = 0;
 
         const config = {
             jsonPath: 'data/kaomojis.json',
@@ -57,6 +58,9 @@ class KaomojiTabContent extends St.Bin {
         this._viewer = new CategorizedItemViewer(extension, settings, config);
         this.set_child(this._viewer);
 
+        this._applyBackButtonPreference();
+        this._alwaysShowTabsSignalId = settings.connect('changed::always-show-tab-bar', () => this._applyBackButtonPreference());
+
         // Connect to Viewer Signals
         this._viewer.connect('item-selected', (source, jsonPayload) => {
             this._onItemSelected(jsonPayload, extension);
@@ -65,6 +69,11 @@ class KaomojiTabContent extends St.Bin {
         this._viewer.connect('back-requested', () => {
             this.emit('navigate-to-main-tab', _("Recently Used"));
         });
+    }
+
+    _applyBackButtonPreference() {
+        const shouldShowBackButton = !this._settings.get_boolean('always-show-tab-bar');
+        this._viewer?.setBackButtonVisible(shouldShowBackButton);
     }
 
     // =====================================================================
@@ -187,6 +196,14 @@ class KaomojiTabContent extends St.Bin {
      * Cleans up resources when the widget is destroyed.
      */
     destroy() {
+        if (this._settings && this._alwaysShowTabsSignalId > 0) {
+            try {
+                this._settings.disconnect(this._alwaysShowTabsSignalId);
+            } catch (e) {
+                // Ignore errors during cleanup
+            }
+            this._alwaysShowTabsSignalId = 0;
+        }
         this._viewer?.destroy();
         super.destroy();
     }

--- a/extension/features/Symbols/tabSymbols.js
+++ b/extension/features/Symbols/tabSymbols.js
@@ -34,6 +34,7 @@ class SymbolsTabContent extends St.Bin {
 
         // Store settings for later use
         this._settings = settings;
+        this._alwaysShowTabsSignalId = 0;
 
         const config = {
             jsonPath: 'data/symbols.json',
@@ -57,6 +58,9 @@ class SymbolsTabContent extends St.Bin {
         this._viewer = new CategorizedItemViewer(extension, settings, config);
         this.set_child(this._viewer);
 
+        this._applyBackButtonPreference();
+        this._alwaysShowTabsSignalId = settings.connect('changed::always-show-tab-bar', () => this._applyBackButtonPreference());
+
         // Connect to Viewer Signals
         this._viewer.connect('item-selected', (source, jsonPayload) => {
             this._onItemSelected(jsonPayload, extension);
@@ -65,6 +69,11 @@ class SymbolsTabContent extends St.Bin {
         this._viewer.connect('back-requested', () => {
             this.emit('navigate-to-main-tab', _("Recently Used"));
         });
+    }
+
+    _applyBackButtonPreference() {
+        const shouldShowBackButton = !this._settings.get_boolean('always-show-tab-bar');
+        this._viewer?.setBackButtonVisible(shouldShowBackButton);
     }
 
     /**
@@ -172,6 +181,14 @@ class SymbolsTabContent extends St.Bin {
      * Cleans up resources when the widget is destroyed.
      */
     destroy() {
+        if (this._settings && this._alwaysShowTabsSignalId > 0) {
+            try {
+                this._settings.disconnect(this._alwaysShowTabsSignalId);
+            } catch (e) {
+                // Ignore cleanup errors
+            }
+            this._alwaysShowTabsSignalId = 0;
+        }
         this._viewer?.destroy();
         super.destroy();
     }

--- a/extension/prefs.js
+++ b/extension/prefs.js
@@ -207,6 +207,13 @@ export default class AllInOneClipboardPreferences extends ExtensionPreferences {
             settings.bind(config.key, row, 'active', Gio.SettingsBindFlags.DEFAULT);
         }
 
+        const alwaysShowTabsRow = new Adw.SwitchRow({
+            title: _('Always Show Top Tabs'),
+            subtitle: _('Keep the main tab buttons visible in every view.')
+        });
+        group.add(alwaysShowTabsRow);
+        settings.bind('always-show-tab-bar', alwaysShowTabsRow, 'active', Gio.SettingsBindFlags.DEFAULT);
+
         const defaultTabRow = new Adw.ComboRow({
             title: _('Default Tab'),
             subtitle: _('The tab that opens when you first open the menu.')

--- a/extension/schemas/org.gnome.shell.extensions.all-in-one-clipboard.gschema.xml
+++ b/extension/schemas/org.gnome.shell.extensions.all-in-one-clipboard.gschema.xml
@@ -49,6 +49,11 @@
             <default>true</default>
             <summary>Enable the 'Clipboard' tab</summary>
         </key>
+        <key name="always-show-tab-bar" type="b">
+            <default>false</default>
+            <summary>Always show the main tab bar</summary>
+            <description>Keep the top tab buttons visible even when opening full-view tabs such as Emoji or GIF.</description>
+        </key>
 
         <!-- Keyboard Shortcuts -->
         <key name="shortcut-toggle-main" type="as">

--- a/extension/stylesheet.css
+++ b/extension/stylesheet.css
@@ -36,6 +36,10 @@
     text-align: center;
 }
 
+.aio-clipboard-container .internal-header {
+    margin-top: 6px;
+}
+
 /* --- Search Specific UI --- */
 .aio-clipboard-container .aio-search-bar-container {
     height: 35px;

--- a/extension/utilities/utilityCategorizedItemViewer.js
+++ b/extension/utilities/utilityCategorizedItemViewer.js
@@ -27,6 +27,7 @@ const RECENTS_CUSTOM_ICON_FILENAME = 'utility-recents-symbolic.svg';
  * @property {Function} renderGridItemFn - A function `(itemData)` that returns an `St.Button` widget for a grid item.
  * @property {Function} renderCategoryButtonFn - A function `(categoryId, extensionPath)` that returns an `St.Button` for a category tab.
  * @property {Function} createSignalPayload - A function `(itemData)` that returns a simple object to be emitted in the 'item-selected' signal.
+ * @property {boolean} [showBackButton=true] - Whether to display the header back button.
  */
 
 /**
@@ -95,6 +96,7 @@ class CategorizedItemViewer extends St.BoxLayout {
         this._searchDebouncer = new Debouncer(() => this._applyFiltersAndRenderGrid(), 250);
 
         this._buildUI();
+        this.setBackButtonVisible(this._config.showBackButton !== false);
 
         this._recentsChangedSignalId = this._recentItemsManager.connect('recents-changed', () => {
             // If the recents list changes while we are viewing it, re-render.
@@ -202,6 +204,21 @@ class CategorizedItemViewer extends St.BoxLayout {
     }
 
     /**
+     * Toggles the visibility and focusability of the back button.
+     * @param {boolean} isVisible - Whether the back button should be shown.
+     */
+    setBackButtonVisible(isVisible) {
+        if (!this._backButton) {
+            return;
+        }
+
+        const shouldShow = Boolean(isVisible);
+        this._backButton.visible = shouldShow;
+        this._backButton.reactive = shouldShow;
+        this._backButton.can_focus = shouldShow;
+    }
+
+    /**
      * Handles Left/Right arrow key presses for navigating between the back button and category tabs.
      * @param {Clutter.Actor} actor - The actor that received the event.
      * @param {Clutter.Event} event - The key press event.
@@ -217,16 +234,20 @@ class CategorizedItemViewer extends St.BoxLayout {
         const firstTab = children[0];
         const lastTab = children[children.length - 1];
 
+        const isBackButtonVisible = this._backButton?.visible;
+
         if (symbol === Clutter.KEY_Left) {
-            if (currentFocus === this._backButton) {
+            if (isBackButtonVisible && currentFocus === this._backButton) {
                 return Clutter.EVENT_STOP; // Trap focus at the start
             }
             if (currentFocus === firstTab) {
-                this._backButton.grab_key_focus();
+                if (isBackButtonVisible) {
+                    this._backButton.grab_key_focus();
+                }
                 return Clutter.EVENT_STOP;
             }
         } else if (symbol === Clutter.KEY_Right) {
-            if (currentFocus === this._backButton) {
+            if (isBackButtonVisible && currentFocus === this._backButton) {
                 firstTab.grab_key_focus();
                 return Clutter.EVENT_STOP;
             }


### PR DESCRIPTION
- This allows for faster navigation between tasks
- Removes back button when tabs are always shown at the top
- This gives the users option to change the layout while still keeping your current design the default 

<img width="672" height="605" alt="image" src="https://github.com/user-attachments/assets/87be8f8d-19be-433a-8aef-14d362886911" />

<img width="762" height="698" alt="image" src="https://github.com/user-attachments/assets/8874aee9-3a1b-412e-8b44-b13168ae9e42" />
