### PR TITLE
Fix: Validate URI `scheme` and `host` before creating `Soup.Message`.

### DIFF
--- a/gnome-extensions/extension/shared/services/serviceImage.js
+++ b/gnome-extensions/extension/shared/services/serviceImage.js
@@ -64,6 +64,12 @@ export const ServiceImage = {
 
             if (!uri) return null;
 
+            const scheme = uri.get_scheme();
+            if (scheme !== 'http' && scheme !== 'https') return null;
+
+            const host = uri.get_host();
+            if (!host) return null;
+
             const message = new Soup.Message({
                 method: 'GET',
                 uri: uri,


### PR DESCRIPTION
SIGABRT kills the entire gnome-shell process when libsoup receives a GLib.Uri with scheme javascript and no host, it can't build a valid internal HTTP URI. which then results in shell crashing. 